### PR TITLE
chore: separate README to rotator and bitmap, leaves simplified root README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 ![build workflow](https://github.com/x0rworld/go-bloomfilter/actions/workflows/go.yml/badge.svg)
 [![Go Reference](https://pkg.go.dev/badge/github.com/x0rworld/go-bloomfilter.svg)](https://pkg.go.dev/github.com/x0rworld/go-bloomfilter)
 
-[go-bloomfilter] is implemented by Golang which supports in-memory and Redis. Moreover, it’s available for a duration-based rotation.
+[go-bloomfilter] is implemented by Golang which supports in-memory and Redis. Moreover, it’s available for a
+duration-based rotation.
 
 ## Resources
 
@@ -12,16 +13,8 @@
 
 ## Features
 
-- [Supporting bitmap]
-  - `InMemory`: backed by [bits-and-blooms/bloom]
-  - `Redis`: backed by [go-redis/redis]
+- [Supporting bitmap]: in-memory and Redis
 - [Rotation]
-  - Supports to manipulate the same key with Redis across multiple machines.
-    - [RotatorMode]
-      - `truncated-time`: manipulate key which is suffix with truncated time instead of current time, 
-                          which means whenever create the bitmap, it produces the same key of Redis bitmap in the same truncated time.
-        - e.g. current time: `2022-09-06 08:24:31.35128`, frequency of rotation: `3h`
-          - the key will be `go-bloomfilter_1662444000000000000`; `1662444000000000000` is unix timestamp of `2022-09-06 06:00:00`.
 
 ## Installation
 
@@ -67,33 +60,29 @@ func main() {
 	if err != nil {
 		log.Println(err)
 		return
-	} 
+	}
 	// data: hello world, exist: false
-	log.Printf("data: %v, exist: %v\n", data, exist) 
+	log.Printf("data: %v, exist: %v\n", data, exist)
 	err = f.Add(data)
 	if err != nil {
 		log.Println(err)
 		return
-	} 
+	}
 	// add data: hello world
-	log.Printf("add data: %s\n", data) 
+	log.Printf("add data: %s\n", data)
 	exist, err = f.Exist(data)
 	if err != nil {
 		log.Println(err)
 		return
-	} 
+	}
 	// data: hello world, exist: true
-	log.Printf("data: %v, exist: %v\n", data, exist) 
+	log.Printf("data: %v, exist: %v\n", data, exist)
 }
 ```
 
 More examples such as rotation could be found in [Examples].
 
 [go-bloomfilter]: https://github.com/x0rworld/go-bloomfilter
-
-[bits-and-blooms/bloom]: https://github.com/bits-and-blooms/bloom
-
-[go-redis/redis]: https://github.com/go-redis/redis
 
 [Examples]: ./example
 
@@ -102,5 +91,3 @@ More examples such as rotation could be found in [Examples].
 [Supporting bitmap]: ./bitmap
 
 [Rotation]: ./filter/rotator
-
-[RotatorMode]: ./config/config.go

--- a/bitmap/README.md
+++ b/bitmap/README.md
@@ -1,0 +1,10 @@
+# bitmap
+
+## Supporting bitmap
+
+- `InMemory`: wraps [bits-and-blooms/bloom]
+- `Redis`: integrates [go-redis/redis] to manipulate bitmap in Redis.
+
+[bits-and-blooms/bloom]: https://github.com/bits-and-blooms/bloom
+
+[go-redis/redis]: https://github.com/go-redis/redim

--- a/filter/rotator/README.md
+++ b/filter/rotator/README.md
@@ -1,0 +1,77 @@
+# Rotator (Rotation)
+
+## Supporting bitmaps
+
+- [In-Memory]
+- [Redis]
+
+## Rotator Mode
+
+- `default`: perform rotation by `RotatorConfig.Freq`. It's **effective with all bitmaps**.
+    - if rotation is performed when `2022-01-02T03:04:05` and `Freq` is `3h`, the next rotation will
+      be `2022-01-02T06:04:05`.
+- `truncated-time`: perform rotation by truncated time and `RotatorConfig.Freq`. It's **only effective
+  with** `bitmap.Redis{}`.
+- Refer following [Explanation](#Explanation) for more information.
+
+### Explanation
+
+- Assume we have `config.FactoryConfig` as following:
+
+```go
+package main
+
+import (
+	"github.com/x0rworld/go-bloomfilter/config"
+)
+
+var cfg = config.FactoryConfig{
+	FilterConfig: config.FilterConfig{
+		BitmapConfig: config.BitmapConfig{Type: config.BitmapTypeRedis},
+		M:            100,
+		K:            2,
+	},
+	RedisConfig: config.RedisConfig{
+		Addr:    "elasticache.us-west-2.amazonaws.com:6379",
+		Timeout: 5 * time.Second,
+		Key:     "bloomfilter",
+	},
+	RotatorConfig: config.RotatorConfig{
+		Enable: true,
+		Freq:   "3h",
+		Mode:   config.RotatorModeTruncatedTime,
+	},
+}
+```
+
+- The current time is 2022-09-06 08:24:31.35128. (timestamp by nano is 1662452671351280000)
+
+Then, the Redis key for bitmap will be generated and manipulated as following:
+
+| Mode             | Redis Key [1]                       | Next Rotation will be at |
+|------------------|-------------------------------------|--------------------------|
+| `default`        | bloomfilter_1662452671351280000     | 2022-09-06 11:24:31      |
+| `truncated-time` | bloomfilter_1662444000000000000 [2] | 2022-09-06 09:00:00      |
+
+- [1]: [bitmap.Redis] manipulates bitmap based on Redis Key.
+- [2]: 1662444000000000000 is timestamp by nano, which is at 2022-09-06 06:00:00.
+
+### Note
+
+Ideally, we assume all machines can produce the closed system time, so go-bloomfilter adopts system time for
+synchronization with `truncated-time`.
+However, it's not robust because we can't guarantee for the consistency of system time and this package doesn't provide
+the synchronization for the time yet.
+
+Unless you handle the consistency problem with system time, please consider suitability of your project before you
+adopt `truncated-time` way if you'd like to rely on system time for synchronization.
+
+[In-Memory]: ../../bitmap/memory.go
+
+[Redis]: ../../bitmap/redis.go
+
+[bitmap]: ../../bitmap
+
+[bitmap.Redis]: ../../bitmap/redis.go
+
+[config.go]: ../../config/config.go


### PR DESCRIPTION
## Description

- chore: separate root README to [rotator] and [bitmap] for simplified root README.

[rotator]: filter/rotator/README.md
[bitmap]: bitmap/README.md